### PR TITLE
git checkout instead of test

### DIFF
--- a/lnbits/Dockerfile
+++ b/lnbits/Dockerfile
@@ -23,7 +23,7 @@ WORKDIR /app
 
 RUN git clone --recursive --single-branch --branch ${LNBITS_BRANCH} -c advice.detachedHead=false \
     https://github.com/lnbits/lnbits . \
-    && test `git rev-parse HEAD` = ${LNBITS_COMMIT_HASH} || exit 1 
+    && git checkout ${LNBITS_COMMIT_HASH} || exit 1 
     
 
 RUN mkdir data


### PR DESCRIPTION
- just checkout the commit hash instead of doing a test, if there is newer commits a test will always fail